### PR TITLE
chore: add lint in test workflow

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,18 @@
+# What
+
+> Include a summary of the changes.
+
+
+# Why
+
+> Describe why is this modification important.
+
+
+# How
+
+> Describe how the modifications are implemented.
+
+
+# Documentation (optional)
+
+> If applicable, add the related documentation.

--- a/.github/workflows/heatrapy-app.yml
+++ b/.github/workflows/heatrapy-app.yml
@@ -24,15 +24,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 . --count --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,4 @@
-name: Python application
+name: Heatrapy application
 
 on:
   push:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest

--- a/heatrapy/dimension_1/objects/object.py
+++ b/heatrapy/dimension_1/objects/object.py
@@ -74,7 +74,7 @@ class Object:
         self.amb_temperature = amb_temperature
 
         # loads the data for each material
-        if materials_path == False:
+        if not materials_path:
             for i in range(len(materials)):
                 tadi = Path(os.path.dirname(os.path.realpath(__file__)) +
                             '/../../database/' + materials[i] + '/' +
@@ -116,8 +116,9 @@ class Object:
                 rhoa = Path(materials_path + materials[i] + '/' + 'rhoa.txt')
                 lheat0 = Path(materials_path + materials[i] + '/' +
                               'lheat0.txt')
-                lheata = Path(materials_path + materials[i] + '/' +
-                                  'lheata.txt')
+                lheata = Path(
+                    materials_path + materials[i] + '/' + 'lheata.txt'
+                )
                 self.materials[i] = mats.CalMatPro(
                     tadi, tadd, cpa, cp0, k0, ka, rho0, rhoa, lheat0, lheata)
 

--- a/heatrapy/dimension_1/objects/single.py
+++ b/heatrapy/dimension_1/objects/single.py
@@ -197,7 +197,7 @@ class SingleObject:
                             temp = np.array(temp)
                             self.online.set_ydata(temp)
                         self.figure.canvas.draw()
-                    except:
+                    except Exception:
                         pass
 
     def deactivate(self, initial_point, final_point):
@@ -234,7 +234,7 @@ class SingleObject:
                             temp = np.array(temp)
                             self.online.set_ydata(temp)
                         self.figure.canvas.draw()
-                    except:
+                    except Exception:
                         pass
 
     def change_power(self, power_type, power, initial_point, final_point):
@@ -390,7 +390,7 @@ class SingleObject:
                                     temp = np.array(temp)
                                     self.online.set_ydata(temp)
                                 self.figure.canvas.draw()
-                        except:
+                        except Exception:
                             pass
 
             # writes the temperature to file_name file ...

--- a/heatrapy/dimension_1/objects/system.py
+++ b/heatrapy/dimension_1/objects/system.py
@@ -206,7 +206,9 @@ class SystemObjects:
                 object_number = object_number + 1
                 obj.time_passed = obj.time_passed + obj.dt
 
-                cond1 = object_number not in [l[0] for l in self.boundaries]
+                cond1 = object_number not in [
+                    boundary[0] for boundary in self.boundaries
+                ]
                 if cond1 or (object_number, 0) in self.boundaries:
 
                     # defines the material properties

--- a/heatrapy/dimension_2/objects/single.py
+++ b/heatrapy/dimension_2/objects/single.py
@@ -602,7 +602,7 @@ class SingleObject:
                                       len(self.object.materials))
                 value_2 = len(self.object.materials)-1
                 norm = matplotlib.colors.BoundaryNorm(value_1, value_2)
-                func = lambda x, pos: qrates[::-1][norm(x)]
+                func = lambda x, pos: qrates[::-1][norm(x)]  # noqa: E731
                 fmt = matplotlib.ticker.FuncFormatter(func)
                 value = np.arange(0, len(self.object.materials)+1)
                 cbar_kw = dict(ticks=value, format=fmt)

--- a/heatrapy/dimension_2/objects/single.py
+++ b/heatrapy/dimension_2/objects/single.py
@@ -127,8 +127,11 @@ class SingleObject:
                                                  origin='lower',
                                                  interpolation='hamming')
                     cbar_kw = {}
-                    cbar = self.ax.figure.colorbar(self.im, ax=self.ax,
-                                                   **cbar_kw)
+                    self.ax.figure.colorbar(
+                        self.im,
+                        ax=self.ax,
+                        **cbar_kw
+                    )
                     self.ax.set_title('Temperature (K)')
                     self.ax.set_xlabel('x axis (m)')
                     self.ax.set_ylabel('y axis (m)')
@@ -151,7 +154,7 @@ class SingleObject:
                     qrates = np.array(['active', 'inactive'])
                     value = np.linspace(0, 1, 2)
                     norm = matplotlib.colors.BoundaryNorm(value, 1)
-                    func = lambda x, pos: qrates[::-1][norm(x)]
+                    func = lambda x, pos: qrates[::-1][norm(x)]  # noqa: E731
                     fmt = matplotlib.ticker.FuncFormatter(func)
                     cbar_kw = dict(ticks=np.arange(-3, 4), format=fmt)
                     cbar_stat = self.ax_state.figure.colorbar(self.im_state,
@@ -186,7 +189,7 @@ class SingleObject:
                     value_1 = np.linspace(0, 1, len(self.object.materials))
                     value_2 = len(self.object.materials)-1
                     norm = matplotlib.colors.BoundaryNorm(value_1, value_2)
-                    func = lambda x, pos: qrates[::-1][norm(x)]
+                    func = lambda x, pos: qrates[::-1][norm(x)]  # noqa: E731
                     fmt = matplotlib.ticker.FuncFormatter(func)
                     cbar_kw = dict(ticks=np.arange(-3, 4), format=fmt)
                     value_1 = self.im_materials
@@ -211,8 +214,11 @@ class SingleObject:
                                                  extent=extent, origin='lower',
                                                  interpolation='hamming')
                     cbar_kw = {}
-                    cbar = self.ax_Q.figure.colorbar(self.im_Q, ax=self.ax_Q,
-                                                     **cbar_kw)
+                    self.ax_Q.figure.colorbar(
+                        self.im_Q,
+                        ax=self.ax_Q,
+                        **cbar_kw
+                    )
                     self.ax_Q.set_title('Q (W/m²)')
                     self.ax_Q.set_xlabel('x axis (m)')
                     self.ax_Q.set_ylabel('y axis (m)')
@@ -231,9 +237,11 @@ class SingleObject:
                                                    origin='lower',
                                                    interpolation='hamming')
                     cbar_kw = {}
-                    cbar = self.ax_Q0.figure.colorbar(self.im_Q0,
-                                                      ax=self.ax_Q0,
-                                                      **cbar_kw)
+                    self.ax_Q0.figure.colorbar(
+                        self.im_Q0,
+                        ax=self.ax_Q0,
+                        **cbar_kw
+                    )
                     self.ax_Q0.set_title('Q0 (W/m²)')
                     self.ax_Q0.set_xlabel('x axis (m)')
                     self.ax_Q0.set_ylabel('y axis (m)')
@@ -303,7 +311,7 @@ class SingleObject:
             cbarlabel = ""  # "state"
             qrates = np.array(['active', 'inactive'])
             norm = matplotlib.colors.BoundaryNorm(np.linspace(0, 1, 2), 1)
-            func = lambda x, pos: qrates[::-1][norm(x)]
+            func = lambda x, pos: qrates[::-1][norm(x)]  # noqa: E731
             fmt = matplotlib.ticker.FuncFormatter(func)
             cbar_kw = dict(ticks=np.arange(-3, 4), format=fmt)
             cbar_state = self.ax_state.figure.colorbar(self.im_state,
@@ -338,7 +346,7 @@ class SingleObject:
                                 len(self.object.materials))
             norm = matplotlib.colors.BoundaryNorm(value,
                                                   len(self.object.materials)-1)
-            func = lambda x, pos: qrates[::-1][norm(x)]
+            func = lambda x, pos: qrates[::-1][norm(x)]  # noqa: E731
             fmt = matplotlib.ticker.FuncFormatter(func)
             cbar_kw = dict(ticks=np.arange(0, len(self.object.materials)+1),
                            format=fmt)
@@ -566,7 +574,7 @@ class SingleObject:
                                state=state, materials_path=self.materials_path)
         try:
             plt.close(self.figure_materials)
-        except:
+        except Exception:
             pass
 
         if self.draw:
@@ -788,7 +796,7 @@ class SingleObject:
                                     self.im.set_clim(vmin=vmin)
                                     self.im.set_clim(vmax=vmax)
                                 self.figure.canvas.draw()
-                            except:
+                            except Exception:
                                 pass
 
             if nw == write_interval:

--- a/heatrapy/mats/calmatpro.py
+++ b/heatrapy/mats/calmatpro.py
@@ -133,7 +133,7 @@ class CalMatPro:
         for line in s:
             latent_values = line.split()
             self.latent_heatA.append(
-                (float(latent_values[0]),float(latent_values[1]))
+                (float(latent_values[0]), float(latent_values[1]))
             )
         input.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,17 @@
 coverage==7.6.1
 cycler==0.10.0
 exceptiongroup==1.2.2
+flake8==7.1.1
 iniconfig==2.0.0
 kiwisolver==1.3.1
 matplotlib==3.3.4
+mccabe==0.7.0
 numpy==1.22.0
 packaging==24.1
 Pillow==9.0.1
 pluggy==1.5.0
+pycodestyle==2.12.1
+pyflakes==3.2.0
 pyparsing==2.4.7
 pytest==8.3.3
 pytest-cov==5.0.0


### PR DESCRIPTION
# What

This PR adds linting in the heatrapy application workflow.


# Why

To make the code readable, we need to follow some lint conventions. flake8 is used for linting in the heatrapy project.


# How

flake8 is included in the requirements. flake8 is also added in the heatrapy application workflow. Some changes in the coded were implemented to follow the rules.