### PR TITLE
ci: add test pypi publication workflow

### DIFF
--- a/.github/workflows/heatrapy-app.yml
+++ b/.github/workflows/heatrapy-app.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - develop
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,10 +1,10 @@
-name: Publish Python 🐍 distribution 📦 to TestPyPI
+name: Publish Python distribution
 
 on: push
 
 jobs:
   build:
-    name: Build distribution 📦
+    name: Build distribution
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +29,8 @@ jobs:
         path: dist/
 
   publish-to-pypi:
-    name: Publish Python 🐍 distribution 📦 to PyPI
+    name: Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest
@@ -47,7 +48,7 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Publish distribution 📦 to PyPI
+    - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
     # Generate a changelog based on the tag
@@ -75,7 +76,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    name: Publish Python distribution to TestPyPI
     needs:
     - build
     runs-on: ubuntu-latest
@@ -93,7 +94,7 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Publish distribution 📦 to TestPyPI
+    - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,53 @@
+name: Publish Python 🐍 distribution 📦 to TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/heatrapy
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -51,3 +51,15 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "✏️ Generate release changelog"
+        uses: heinrichreimer/action-github-changelog-generator@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "📄 Display Changelog"
+        run: |
+          echo "Generated Changelog:"
+          echo "${{ steps.changelog_gen.outputs.changelog }}"

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -59,6 +59,7 @@ jobs:
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          sinceTag: v2.0.0
       - name: "📄 Display Changelog"
         run: |
           echo "Generated Changelog:"

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -28,6 +28,52 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/heatrapy
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    # Generate a changelog based on the tag
+    - name: Fetch all tags
+      run: git fetch --tags --force
+    - name: Get Previous Tag
+      id: previous_tag
+      run: |
+        previous_tag=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1))
+        echo "previous_tag=$previous_tag" >> $GITHUB_ENV
+    - name: Generate Changelog for Release
+      id: changelog_gen
+      uses: heinrichreimer/action-github-changelog-generator@v2.3
+      with:
+        sinceTag: ${{ env.previous_tag }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Create a new release using the changelog
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        body: ${{ steps.changelog_gen.outputs.changelog }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
     needs:
@@ -51,16 +97,3 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
-
-  changelog:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "✏️ Generate release changelog"
-        uses: heinrichreimer/action-github-changelog-generator@v2.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sinceTag: v2.0.0
-      - name: "📄 Display Changelog"
-        run: |
-          echo "Generated Changelog:"
-          echo "${{ steps.changelog_gen.outputs.changelog }}"

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,6 +1,10 @@
 name: Publish Python distribution
 
-on: push
+on:
+  push:
+    branches:
+      - master
+      - develop
 
 jobs:
   build:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """heatrapy: Library for simulating heat transfer processes
 
-Computes heat transfer processes in solids for 1-dimensional models.
-It includes two models for simulating caloric systems.
+Computes heat transfer processes in solids for 1D and 2D models.
 
 """
 
@@ -13,12 +12,11 @@ description += 'transfer processes by using the finite difference method. The '
 description += 'packages is based on thermal objects. Two different '
 description += 'approaches can be used: single thermal object and a system of '
 description += 'thermal objects that can contact with each other. The heatrapy'
-description += 'package includes the modeling of caloric effects and the '
-description += 'incorporation of phase transitions.'
+description += 'package includes the incorporation of phase transitions.'
 
 
 setup(name='heatrapy',
-      version='2.0.3',
+      version='2.0.4',
       description='Library for simulating 1D and 2D heat transfer processes',
       long_description=description,
       classifiers=[


### PR DESCRIPTION
# What

This PR includes the workflows for publishing the heatrapy package.


# Why

Whenever a new version is ready to be released, a tag is created, and the publication of the package is performed manually on Pypi. This PR creates the github actions workflow that publishes automatically a new version.


# How

When merging a pull request into the develop branch, a publication is performed on test.pypi.
When creating a tag, a publication is performed on pypi.
