### PR TITLE
docs: fix documentation for Q0 and Q

### DIFF
--- a/heatrapy/dimension_1/objects/object.py
+++ b/heatrapy/dimension_1/objects/object.py
@@ -37,8 +37,8 @@ class Object:
         of the materials. True if there are an applied field and False if them
         field is absent. `materials_path` is absolute path of the materials
         database. If false, then the materials database is the standard
-        heatrapy database. `Q` is a list of fixed heat source coefficient and
-        `Q0` is a list of temperature dependent heat source coefficient.
+        heatrapy database. `Q0` is a list of fixed heat source coefficient and
+        `Q` is a list of temperature dependent heat source coefficient.
 
         """
         # check the validity of inputs

--- a/heatrapy/dimension_2/objects/object.py
+++ b/heatrapy/dimension_2/objects/object.py
@@ -36,8 +36,8 @@ class Object:
         initial state of the materials. True if there are an applied field and
         False if them field is absent. `materials_path` is absolute path of the
         materials database. If false, then the materials database is the
-        standard heatrapy database. `Q` is a list of fixed heat source
-        coefficient and `Q0` is a list of temperature dependent heat source
+        standard heatrapy database. `Q0` is a list of fixed heat source
+        coefficient and `Q` is a list of temperature dependent heat source
         coefficient.
 
         """

--- a/heatrapy/dimension_2/objects/single.py
+++ b/heatrapy/dimension_2/objects/single.py
@@ -41,8 +41,8 @@ class SingleObject:
         `temperature`, `materials`, `state`, `Q` and `Q0`. If the list is
         empty, then no drawing is performed. `draw_scale` is a list of two
         values, representing the minimum and maximum temperature to be drawn.
-        If None, there are no limits. `Q` is a list of fixed heat source
-        coefficient and `Q0` is a list of temperature dependent heat source
+        If None, there are no limits. `Q0` is a list of fixed heat source
+        coefficient and `Q` is a list of temperature dependent heat source
         coefficient.
 
         """


### PR DESCRIPTION
## What
The docstrings mentioning the `Q` and `Q0` parameters are incorrect. This PR fixes it.

## Why
Since the documentation is based on the docstrings it is important to have it sound.

## How
* [`heatrapy/dimension_1/objects/object.py`](diffhunk://#diff-177c46de32e5d486f154ad4e1dd620679c72c51f92cb2b8adcac0da1088208fbL40-R41): Swapped the descriptions of `Q` and `Q0` to correctly indicate that `Q0` is a list of fixed heat source coefficients and `Q` is a list of temperature-dependent heat source coefficients.
* [`heatrapy/dimension_2/objects/object.py`](diffhunk://#diff-f4dbd973698f86a439f22a061fff87ff0fefea74c91056026a29314ff4e4741eL39-R40): Corrected the descriptions of `Q` and `Q0` to match the intended meaning, where `Q0` is for fixed heat source coefficients and `Q` is for temperature-dependent coefficients.
* [`heatrapy/dimension_2/objects/single.py`](diffhunk://#diff-b4555e6857682c924c14b3a3c3a8b6040c565c58fea716b8c8d19cf71dcbe810L44-R45): Updated the descriptions of `Q` and `Q0` to ensure clarity, specifying that `Q0` is for fixed coefficients and `Q` is for temperature-dependent coefficients.

## Documentation
This PR fixes the issue #16